### PR TITLE
Use composer type library instead of project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "klaussilveira/simple-shm",
     "license": "BSD-2-Clause",
-    "type": "project",
+    "type": "library",
     "description": "SimpleSHM is a simple and small abstraction layer for shared memory manipulation using PHP.",
     "autoload": {
         "psr-0": { "Simple\\SHM": "src/" }


### PR DESCRIPTION
This PR changes the Composer package type to `library` which is better suited for libraries.
