### PR TITLE
Test modern versions of PHP and use current Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,6 @@ php:
     - 5.5
     - 5.6
     - 7.0
-    - hhvm
-
-matrix:
-    allow_failures:
-        - php: hhvm
 
 script:
     - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,26 @@
+sudo: false
+
 language: php
 
 before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install
+    - travis_retry composer self-update
+    - travis_retry composer install --no-interaction
 
 php:
-  - 5.3
-  - 5.4
+    - 5.3
+    - 5.4
+    - 5.5
+    - 5.6
+    - 7.0
+    - hhvm
 
-script: phpunit
+matrix:
+    allow_failures:
+        - php: hhvm
+
+script:
+    - vendor/bin/phpunit
+
+cache:
+    directories:
+        - $HOME/.composer/cache

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,8 @@
     },
     "require": {
         "php": ">=5.3.3"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8"
     }
 }


### PR DESCRIPTION
This PR update Travis config to use new faster container base architecture. It also adds tests for  PHP versions 5.5, 5.6, 7.0 and hhvm. Uses local phpunit to be sure old versions of PHP are supported. Caches Composer dependencies for faster build.
