### PR TITLE
Use consistent IPC key instead of random integer as id

### DIFF
--- a/src/Simple/SHM/Block.php
+++ b/src/Simple/SHM/Block.php
@@ -43,10 +43,10 @@ class Block
             $this->id = $this->generateID();
         } else {
             $this->id = $id;
+        }
 
-            if($this->exists($this->id)) {
-                $this->shmid = shmop_open($this->id, "w", 0, 0);
-            }
+        if($this->exists($this->id)) {
+            $this->shmid = shmop_open($this->id, "w", 0, 0);
         }
     }
 
@@ -54,11 +54,11 @@ class Block
      * Generates a random ID for a shared memory block
      *
      * @access protected
-     * @return int Randomly generated ID, between 1 and 65535
+     * @return int System V IPC key generated from pathname and a project identifier
      */
     protected function generateID()
     {
-        $id = mt_rand(1, 65535);
+        $id = ftok(__FILE__, "b");
         return $id;
     }
 
@@ -76,7 +76,6 @@ class Block
     public function exists($id)
     {
         $status = @shmop_open($id, "a", 0, 0);
-
         return $status;
     }
 

--- a/tests/Simple/SHM/Test/BlockTest.php
+++ b/tests/Simple/SHM/Test/BlockTest.php
@@ -34,4 +34,16 @@ class BlockTest extends \PHPUnit_Framework_TestCase
         $data = $memory->read();
         $this->assertEquals('Sample 2', $data);
     }
+
+    public function testIsPersistingNewBlockWithoutId()
+    {
+        $memory = new Block;
+        $this->assertInstanceOf('Simple\\SHM\\Block', $memory);
+        $memory->write('Sample 3');
+        unset($memory);
+
+        $memory = new Block;
+        $data = $memory->read();
+        $this->assertEquals('Sample 3', $data);
+    }
 }


### PR DESCRIPTION
Currently the data stored into shared memory is not accessible between requests unless you specify the `id` manually. This PR addresses the issue by using consistent IPC key generated with [ftok()](http://php.net/manual/en/function.ftok.php) function.

Also fixes bug #3.
